### PR TITLE
Upgrade to Laravel 13.7 / PHPUnit 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.idea
 composer.phar
 composer.lock
+.phpunit.cache
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@ DreamFactory Limits Configuration Package
 
 This is a service library for the DreamFactory platform containing API Limits service and resources.
 This is an add on to the DreamFactory Core library and requires the [df-core repository] (http://github.com/dreamfactorysoftware/df-core).
+
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,21 @@
     "issues": "https://github.com/dreamfactorysoftware/df-limits/issues",
     "wiki":   "https://wiki.dreamfactory.com"
   },
+  "version":     "0.7.99",
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.5"
+    "php":                    "^8.3",
+    "laravel/helpers":        "^1.8",
+    "dreamfactory/df-core":   "~1.0.4",
+    "dreamfactory/df-system": "~0.6.2"
+  },
+  "require-dev": {
+    "laravel/framework":     "^13.7",
+    "mockery/mockery":       "^1.6",
+    "nunomaduro/collision":  "^8.6",
+    "phpunit/phpunit":       "^11.5.3",
+    "orchestra/testbench":   "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="/vagrant/bootstrap/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false">
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Limits Testing">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/LimitsTest.php
+++ b/tests/LimitsTest.php
@@ -35,7 +35,7 @@ class LimitsTest extends TestCase
         "last_modified_by_id" => 1
     ];
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         //$this->createLimits();


### PR DESCRIPTION
## Summary
- Bumps `composer.json` to the Laravel 13.7 dep matrix (php `^8.3`, `laravel/framework ^13.7`, `phpunit/phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `laravel/helpers ^1.8` for `array_get`/`camel_case`/`array_except` polyfills).
- Bumps `dreamfactory/df-core` to `~1.0.4` and `dreamfactory/df-system` to `~0.6.2` to align with their `shift/laravel-13` release lines.
- Pins a synthetic top-level `version: 0.7.99` so siblings constrained by `~0.7` can resolve this branch via composer path-repos during the multi-package wave migration.
- Modernizes `phpunit.xml` for PHPUnit 11 — drops removed attributes (`backupStaticAttributes`, `convertErrors/Notices/WarningsToExceptions`, `syntaxCheck`), points `bootstrap` at `vendor/autoload.php`, adds `cacheDirectory`, tightens `directory suffix=".php"` to `Test.php`.
- Adds `: void` return type to `LimitsTest::setUp()` for PHPUnit 9+ LSP enforcement.
- Adds `.phpunit.cache` / `.phpunit.result.cache` to `.gitignore`.

**No source changes were required.** Surveyed for the standard 21 L11→L13 invariants:
- No `Fruitcake\Cors\CorsService` references, no `DispatchesJobs` trait usage, no `setupBeforeClass` typos, no `getDates()` overrides, no direct `Illuminate\Database\Connection|Builder|Grammar` extension, no `web` middleware-group dependence.
- The package's `Illuminate\Cache\RateLimiter` usage (`attempts`, `availableIn`, `clear`, `tooManyAttempts`, `hit`, `retriesLeft`) is **API-stable** across L11..L13.7 — confirmed via reflection on `vendor/laravel/framework/v13.7.0`.
- `EvaluateLimits::handle($request, Closure $next)` is a custom middleware not extending `ThrottleRequests`, so the L11 throttle-middleware signature change does not apply.
- `FileStore` and `RedisStore` constructors gained an optional `$serializableClasses` arg in L13 — backwards-compatible with the existing two- and three-arg call sites in `LimitCache::__construct()`.

## Test plan
**Stage 1 — Isolated install + autoload smoke (in `dreamfactory_web_1` container):**
- [x] `composer validate --strict --no-check-publish` passes (only the expected `version` and `Proprietary` warnings).
- [x] `composer install` resolves with path-repos for `df-core 1.0.99`, `df-system 0.6.99`, `df-database 1.4.99` (all on `shift/laravel-13`).
- [x] `php -l` clean across all six source files.
- [x] All six namespaced classes autoload under L13.7 + PHPUnit 11.5.55:
  - `DreamFactory\Core\Limit\ServiceProvider`
  - `DreamFactory\Core\Limit\Models\Limit`
  - `DreamFactory\Core\Limit\Resources\System\Limit`
  - `DreamFactory\Core\Limit\Resources\System\LimitCache`
  - `DreamFactory\Core\Limit\Http\Middleware\EvaluateLimits`
  - `DreamFactory\Core\Limit\Handlers\Events\EventHandler`
- [x] Helper polyfills present: `array_get`, `camel_case`, `array_except`.
- [x] PHPUnit 11.5.55 boots (1 test errors with `Unable to locate bootstrap/app.php` — expected, the test extends `DreamFactory\Core\Testing\TestCase` which requires a host-app bootstrap; deferred to Stage 2 / host-app integration suites).

**Stage 2 — Host-app integration (cloned `dreamfactory/dreamfactory@shift-173254`):**
- [x] `composer install --no-dev` against a host composer.json with `df-limits` added as a path-repo + `~0.7.0` require resolves cleanly under L13.7.0 (df-mongo-logs / df-git / df-oauth / df-mcp-server stripped per the standard sibling-blocker scrub list, `MongoDB\Laravel\MongoDBServiceProvider` commented in `config/app.php`).
- [x] Autoload-only smoke confirms all six classes load and `Illuminate\Foundation\Application::VERSION === "13.7.0"`.
- [x] `Illuminate\Cache\RateLimiter` reflection confirms the six methods used by `LimitCache.php` exist with compatible signatures.
- [ ] Full host-app `php artisan test` once all sibling packages reach L13 — gated on Wave 4+.

## Notes for downstream waves
- df-limits is the second pure-Eloquent + middleware Gold package to land L13 with **zero source patches** (df-database was the first). The L13 risk for df-limits is entirely in its df-core / df-system base class chain, not in its own code.
- `Illuminate\Cache\FileStore` and `RedisStore` constructors gained `$serializableClasses` (optional, defaults to empty). Other packages instantiating these directly are safe.