### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.idea
 composer.phar
 composer.lock
+.phpunit.cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,21 @@
     "issues": "https://github.com/dreamfactorysoftware/df-limits/issues",
     "wiki":   "https://wiki.dreamfactory.com"
   },
+  "version":     "0.7.99",
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.5"
+    "php":                    "^8.3",
+    "laravel/helpers":        "^1.8",
+    "dreamfactory/df-core":   "~1.0.4",
+    "dreamfactory/df-system": "~0.6.2"
+  },
+  "require-dev": {
+    "laravel/framework":     "^13.7",
+    "mockery/mockery":       "^1.6",
+    "nunomaduro/collision":  "^8.6",
+    "phpunit/phpunit":       "^11.5.3",
+    "orchestra/testbench":   "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="/vagrant/bootstrap/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false">
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Limits Testing">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Models/Limit.php
+++ b/src/Models/Limit.php
@@ -81,6 +81,33 @@ class Limit extends BaseSystemModel
     ];
 
     /**
+     * Reduce a URL endpoint to a stable bucketed form for rate-limit
+     * keying. Without this, record-ID-bearing URLs balloon the keyspace
+     * and let an attacker bypass rate limits by varying the ID.
+     */
+    public static function bucketEndpoint(string $endpoint): string
+    {
+        $segments = explode('/', $endpoint);
+        foreach ($segments as $i => $segment) {
+            if ($segment === '') {
+                continue;
+            }
+            if (ctype_digit($segment)) {
+                $segments[$i] = ':id';
+            } elseif (preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $segment)) {
+                $segments[$i] = ':uuid';
+            } elseif (preg_match('/^[0-9a-f]{32,}$/i', $segment)) {
+                $segments[$i] = ':hash';
+            }
+        }
+        $bucketed = implode('/', $segments);
+        if (strlen($bucketed) > 256) {
+            $bucketed = substr($bucketed, 0, 256);
+        }
+        return $bucketed;
+    }
+
+    /**
      * Resolves and builds unique key based on limit type.
      *
      * @param $limitType
@@ -95,6 +122,10 @@ class Limit extends BaseSystemModel
      */
     public function resolveCheckKey($limitType, $userId, $roleId, $serviceId, $endpoint, $verb, $limitPeriod)
     {
+        // Bucket the endpoint so record-ID variance doesn't create
+        // per-request rate-limit buckets that defeat the limit.
+        $endpoint = is_string($endpoint) ? self::bucketEndpoint($endpoint) : $endpoint;
+
         if (isset(self::$limitTypes[$limitType])) {
 
             switch ($limitType) {

--- a/tests/LimitsTest.php
+++ b/tests/LimitsTest.php
@@ -35,7 +35,7 @@ class LimitsTest extends TestCase
         "last_modified_by_id" => 1
     ];
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         //$this->createLimits();

--- a/tests/Security/EndpointBucketTest.php
+++ b/tests/Security/EndpointBucketTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DreamFactory\Core\Limit\Tests\Security;
+
+use DreamFactory\Core\Limit\Models\Limit;
+use PHPUnit\Framework\TestCase;
+
+class EndpointBucketTest extends TestCase
+{
+    /** @dataProvider bucketProvider */
+    public function testBucket(string $input, string $expected): void
+    {
+        $this->assertSame($expected, Limit::bucketEndpoint($input));
+    }
+
+    public static function bucketProvider(): array
+    {
+        return [
+            ['db/_table/users/12345', 'db/_table/users/:id'],
+            ['db/_table/orders/42/items/7', 'db/_table/orders/:id/items/:id'],
+            ['db/_table/users/550e8400-e29b-41d4-a716-446655440000', 'db/_table/users/:uuid'],
+            ['files/abcdef0123456789abcdef0123456789', 'files/:hash'],
+            ['db/_schema', 'db/_schema'],
+        ];
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
