### PR TITLE
fix: remove stale composer.json version override (df-commercial 7.6.0 gold blocker)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,50 +1,49 @@
 {
-  "name":        "dreamfactory/df-limits",
+  "name": "dreamfactory/df-limits",
   "description": "Limits configuration package for DreamFactory.",
-  "keywords":    [
+  "keywords": [
     "dreamfactory",
     "limits"
   ],
-  "homepage":    "https://www.dreamfactory.com/",
-  "license":     "Proprietary",
-  "authors":     [
+  "homepage": "https://www.dreamfactory.com/",
+  "license": "Proprietary",
+  "authors": [
     {
-      "name":  "DreamFactory Team",
+      "name": "DreamFactory Team",
       "email": "code@dreamfactory.com"
     }
   ],
-  "support":     {
-    "email":  "dspsupport@dreamfactory.com",
+  "support": {
+    "email": "dspsupport@dreamfactory.com",
     "source": "https://github.com/dreamfactorysoftware/df-limits",
     "issues": "https://github.com/dreamfactorysoftware/df-limits/issues",
-    "wiki":   "https://wiki.dreamfactory.com"
+    "wiki": "https://wiki.dreamfactory.com"
   },
-  "version":     "0.7.99",
   "minimum-stability": "dev",
   "prefer-stable": true,
-  "require":     {
-    "php":                    "^8.3",
-    "laravel/helpers":        "^1.8",
-    "dreamfactory/df-core":   "~1.0.4",
+  "require": {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4",
     "dreamfactory/df-system": "~0.6.2"
   },
   "require-dev": {
-    "laravel/framework":     "^13.7",
-    "mockery/mockery":       "^1.6",
-    "nunomaduro/collision":  "^8.6",
-    "phpunit/phpunit":       "^11.5.3",
-    "orchestra/testbench":   "^11.0"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
-  "autoload":    {
+  "autoload": {
     "psr-4": {
       "DreamFactory\\Core\\Limit\\": "src/"
     }
   },
-  "extra":       {
+  "extra": {
     "branch-alias": {
       "dev-develop": "0.7.x-dev"
     },
-    "laravel":      {
+    "laravel": {
       "providers": [
         "DreamFactory\\Core\\Limit\\ServiceProvider"
       ]


### PR DESCRIPTION
## Remove hardcoded `version` override from composer.json

### The bug
`composer.json` has a hardcoded `"version": "0.7.99"` field. When composer indexes this package (whether via the VCS resolver or packagist), the JSON value **overrides** any git-tag-derived version. The result: every tagged release after 0.7.99 is registered with composer as 0.7.99, silently masked behind the existing 0.7.x tags.

This means `dreamfactory/df-limits 0.11.1` (tagged on github) is invisible to composer — consumers pinning `~0.11.1` cannot resolve:

```
Root composer.json requires dreamfactory/df-limits ~0.11.1,
found dreamfactory/df-limits[..., 0.11.0]
but it does not match the constraint.
```

Surfaces during the **df-commercial 7.6.0** release prep — the gold tier blocks on this.

### Why the override exists
It was likely added years ago for an isolated-install workflow (root package needed a concrete version to satisfy a path-repo alias). It is harmful in tagged releases — for tagged packages, the git tag IS the version of record. Composer's documentation explicitly warns against setting `version` in composer.json for packages distributed via tags.

### The fix
Remove the `"version"` field from `composer.json`. Composer will then use the tag-derived version (0.11.1, 0.11.2, …) the way the convention expects.

### Other diff noise
JSON pretty-printer normalized the original double-space column alignment. No semantic change.

### Tag-cut request
Please re-tag **0.11.1** (force-push the tag to point at the merge commit) or cut **0.11.2** so df-commercial 7.6.0 can resolve. df-commercial PR [#85](https://github.com/dreamfactorysoftware/df-commercial/pull/85) is blocked on this.

### Test plan
- [ ] CI green
- [ ] `composer show dreamfactory/df-limits --all` after the new tag lists 0.11.x correctly
- [ ] df-commercial's gold tier `composer update` resolves df-limits ~0.11.1 cleanly
